### PR TITLE
Fix resources which should be global

### DIFF
--- a/lister/cloudfront_cachepolicy.go
+++ b/lister/cloudfront_cachepolicy.go
@@ -44,7 +44,7 @@ func (l AWSCloudfrontCachePolicy) List(ctx context.AWSetsCtx) (*resource.Group, 
 			}
 			if policies := res.CachePolicyList; policies != nil {
 				for _, v := range policies.Items {
-					r := resource.New(ctx, resource.CloudFrontCachePolicy, v.CachePolicy.Id, v.CachePolicy.Id, v)
+					r := resource.NewGlobal(ctx, resource.CloudFrontCachePolicy, v.CachePolicy.Id, v.CachePolicy.Id, v)
 					rg.AddResource(r)
 				}
 				if policies.NextMarker == nil {

--- a/lister/cloudfront_originrequestpolicy.go
+++ b/lister/cloudfront_originrequestpolicy.go
@@ -44,7 +44,7 @@ func (l AWSCloudfrontOriginRequestPolicy) List(ctx context.AWSetsCtx) (*resource
 			}
 			if policies := res.OriginRequestPolicyList; policies != nil {
 				for _, v := range policies.Items {
-					r := resource.New(ctx, resource.CloudFrontOriginRequestPolicy, v.OriginRequestPolicy.Id, v.OriginRequestPolicy.Id, v)
+					r := resource.NewGlobal(ctx, resource.CloudFrontOriginRequestPolicy, v.OriginRequestPolicy.Id, v.OriginRequestPolicy.Id, v)
 					rg.AddResource(r)
 				}
 				if policies.NextMarker == nil {

--- a/lister/iam_user.go
+++ b/lister/iam_user.go
@@ -48,7 +48,7 @@ func (l AWSIamUser) List(ctx context.AWSetsCtx) (*resource.Group, error) {
 				for akPaginator.Next(ctx.Context) {
 					akPage := akPaginator.CurrentPage()
 					for _, ak := range akPage.AccessKeyMetadata {
-						akR := resource.New(ctx, resource.IamAccessKey, ak.AccessKeyId, ak.AccessKeyId, ak)
+						akR := resource.NewGlobal(ctx, resource.IamAccessKey, ak.AccessKeyId, ak.AccessKeyId, ak)
 						akR.AddRelation(resource.IamUser, user.UserId, "")
 
 						lastUsed, err := svc.GetAccessKeyLastUsedRequest(&iam.GetAccessKeyLastUsedInput{


### PR DESCRIPTION
The following resources should be global:
 * cloudfront/cachepolicy
 * cloudfront/originrequestpolicy
 * iam/accesskey

Currently each time I run awsets they appear under different regions.